### PR TITLE
Add customizable retry values

### DIFF
--- a/lib/job_chains/job_chains_middleware.rb
+++ b/lib/job_chains/job_chains_middleware.rb
@@ -17,7 +17,7 @@ class JobChainsMiddleware
   end
   
   # Check preconditions in Sidekiq jobs
-  def check_preconditions(worker, args)
+  def check_preconditions(worker, args = [])
     return true unless worker.respond_to? :before
     if args[-1].kind_of?(Hash)
       params = args[-1]
@@ -34,13 +34,15 @@ class JobChainsMiddleware
 
     unless before_passed?(worker)
       attempts += 1
-      if attempts > @check_attempts
-        error_message = "Attempted #{worker.class}, but preconditions were never met!"
+      check_attempts = check_attempts(worker)
+      if attempts > check_attempts
+        error_message = "Attempted #{worker.class} #{check_attempts} times, but preconditions were never met!"
         Honeybadger.notify(:error_message => error_message, :parameters => {:args => args})
       else
+        retry_duration = retry_seconds(worker)
         params['precondition_checks'] = attempts
-        Sidekiq::Client.enqueue_in(@retry_seconds.seconds, worker.class, *args)
-        Rails.logger.info("Pre-conditions for #{worker.class} failed, delaying by #{@retry_seconds} seconds.")
+        Sidekiq::Client.enqueue_in(retry_duration.seconds, worker.class, *args)
+        Rails.logger.info("Pre-conditions for #{worker.class} failed, delaying by #{retry_duration} seconds.")
       end
       return false
     end
@@ -51,8 +53,9 @@ class JobChainsMiddleware
   def check_postconditions(worker, args)
     return true unless worker.respond_to? :after
     attempts = 1
-    attempts += 1 until attempts > @check_attempts || after_passed?(worker)
-    if attempts > @check_attempts
+    check_attempts = check_attempts(worker)
+    attempts += 1 until attempts > check_attempts || after_passed?(worker)
+    if attempts > check_attempts
       error_message = "Finished #{worker.class}, but postconditions failed!"
       Honeybadger.notify(:error_message => error_message, :parameters => {:args => args})
       return false
@@ -73,5 +76,13 @@ class JobChainsMiddleware
   rescue
     Honeybadger.notify(e)
     false
+  end
+  
+  def retry_seconds(worker)
+    (worker.respond_to? :retry_seconds) ? worker.retry_seconds : @retry_seconds
+  end
+  
+  def check_attempts(worker)
+    (worker.respond_to? :check_attempts) ? worker.check_attempts : @check_attempts
   end
 end

--- a/lib/job_chains/linked_job.rb
+++ b/lib/job_chains/linked_job.rb
@@ -1,12 +1,18 @@
 module LinkedJob
-  CHECK_ATTEMPTS = 3
-
   def before
     true
   end
   
   def after
     true
+  end
+
+  def check_attempts
+    3
+  end
+  
+  def retry_seconds
+    300
   end
   
   # Check preconditions in Resque jobs
@@ -20,13 +26,13 @@ module LinkedJob
     attempts = params['precondition_checks'].try(:to_i) || 1
     unless before_passed?
       attempts += 1
-      if attempts > CHECK_ATTEMPTS
+      if attempts > check_attempts
         error_message = "Attempted #{self}, but preconditions were never met!"
         Honeybadger.notify(:error_message => error_message, :parameters => {:args => args})
       else
         params['precondition_checks'] = attempts
-        Resque.enqueue_in(5.minutes, self, *args)
-        Rails.logger.info("Pre-conditions for #{self} failed, delaying by 5 minutes.")
+        Resque.enqueue_in(retry_seconds, self, *args)
+        Rails.logger.info("Pre-conditions for #{self} failed, delaying by #{retry_seconds} seconds.")
       end
       raise Resque::Job::DontPerform
     end
@@ -35,8 +41,8 @@ module LinkedJob
   # Check postconditions in Resque jobs
   def after_perform_check_postconditions(*args)
     attempts = 1
-    attempts += 1 until attempts > CHECK_ATTEMPTS || after_passed?
-    if attempts > CHECK_ATTEMPTS
+    attempts += 1 until attempts > check_attempts || after_passed?
+    if attempts > check_attempts
       error_message = "Finished #{self}, but postconditions failed!"
       Honeybadger.notify(:error_message => error_message, :parameters => {:args => args})
     end

--- a/spec/job_chains/job_chains_middleware_spec.rb
+++ b/spec/job_chains/job_chains_middleware_spec.rb
@@ -14,6 +14,14 @@ describe JobChainsMiddleware do
       true
     end
     
+    def check_attempts
+      5
+    end
+
+    def retry_seconds
+      10
+    end
+    
     def perform
       
     end
@@ -67,7 +75,7 @@ describe JobChainsMiddleware do
       it "should enqueue for later and return false" do
         @worker.should_receive(:before).and_return(false)
         Honeybadger.should_not_receive(:notify)
-        Sidekiq::Client.should_receive(:enqueue_in).with(300.seconds, DummySidekiqWorker, 'precondition_checks' => 2)
+        Sidekiq::Client.should_receive(:enqueue_in).with(10.seconds, DummySidekiqWorker, 'precondition_checks' => 2)
         subject.check_preconditions(@worker, ['precondition_checks' => '1']).should be_false
       end
     end
@@ -76,7 +84,7 @@ describe JobChainsMiddleware do
         @worker.should_receive(:before).and_return(false)
         Honeybadger.should_receive(:notify)
         Sidekiq::Client.should_not_receive(:enqueue_in)
-        subject.check_preconditions(@worker, ['precondition_checks' => '3']).should be_false
+        subject.check_preconditions(@worker, ['precondition_checks' => '5']).should be_false
       end
     end
   end
@@ -100,7 +108,7 @@ describe JobChainsMiddleware do
     end    
     context "when after block fails" do
       it "should notify Honeybadger and return false" do
-        @worker.should_receive(:after).exactly(3).times.and_return(false)
+        @worker.should_receive(:after).exactly(5).times.and_return(false)
         Honeybadger.should_receive(:notify)
         subject.check_postconditions(@worker, [{}]).should be_false
       end


### PR DESCRIPTION
- Sidekiq jobs and Resque workers can specify their own `check_attempts` and `retry_seconds`.
- Minor fix for param parsing.
