### PR TITLE
Use Sidekiq's built-in retries and pass in args to before and after

### DIFF
--- a/lib/job_chains.rb
+++ b/lib/job_chains.rb
@@ -1,2 +1,3 @@
 require 'job_chains/job_chains_middleware'
 require 'job_chains/linked_job'
+require 'silent_sidekiq_error'

--- a/lib/job_chains/version.rb
+++ b/lib/job_chains/version.rb
@@ -1,3 +1,3 @@
 module JobChains
-  VERSION = "0.0.2"
+  VERSION = "0.1.0"
 end

--- a/lib/silent_sidekiq_error.rb
+++ b/lib/silent_sidekiq_error.rb
@@ -1,0 +1,5 @@
+# Specific error to be thrown when Sidekiq retries a worker, without sending notifications
+# For use by RetriesExhaustedMiddleware
+class SilentSidekiqError < StandardError
+  
+end

--- a/spec/job_chains/job_chains_middleware_spec.rb
+++ b/spec/job_chains/job_chains_middleware_spec.rb
@@ -14,14 +14,6 @@ describe JobChainsMiddleware do
       true
     end
     
-    def check_attempts
-      5
-    end
-
-    def retry_seconds
-      10
-    end
-    
     def perform
       
     end
@@ -42,20 +34,34 @@ describe JobChainsMiddleware do
       before do
         @worker = DummySidekiqWorker.new
       end
-      context "when it fails precondition check" do
-        it "should not do anything" do
-          subject.should_receive(:check_preconditions).and_return(false)
-          @worker.should_not_receive(:perform)
-          subject.should_not_receive(:check_postconditions)
-          subject.call(@worker, {}, 'default') { @worker.perform }
-        end
-      end
-      context "when it passes precondition check" do
+      context "when the precondition check passes" do
         it "should yield and do postcondition check" do
-          subject.should_receive(:check_preconditions).and_return(true)
+          subject.should_receive(:check_preconditions)
           @worker.should_receive(:perform)
           subject.should_receive(:check_postconditions)
           subject.call(@worker, {}, 'default') { @worker.perform }
+        end
+      end
+      context "when the precondition check throws a SilentSidekiqError" do
+        it "should propogate the error" do
+          subject.should_receive(:check_preconditions).and_raise(SilentSidekiqError)
+          @worker.should_not_receive(:perform)
+          subject.should_not_receive(:check_postconditions)
+          
+          expect {
+            subject.call(@worker, {}, 'default') { @worker.perform }
+          }.to raise_error(SilentSidekiqError)
+        end
+      end
+      context "when the precondition check throws a RuntimeError" do
+        it "should propogate the error" do
+          subject.should_receive(:check_preconditions).and_raise("Runtime Error")
+          @worker.should_not_receive(:perform)
+          subject.should_not_receive(:check_postconditions)
+          
+          expect {
+            subject.call(@worker, {}, 'default') { @worker.perform }
+          }.to raise_error("Runtime Error")
         end
       end
     end
@@ -65,26 +71,52 @@ describe JobChainsMiddleware do
     before do
       @worker = DummySidekiqWorker.new
     end
+    context "when skip_before option is specified" do
+      it "should not check before block" do
+        @worker.should_not_receive(:before)
+        subject.check_preconditions(@worker, 'skip_before' => 'true')
+      end
+    end
     context "when before block passes" do
-      it "should return true" do
+      it "should not raise an error" do
         @worker.should_receive(:before).and_return(true)
-        subject.check_preconditions(@worker, [{}]).should be_true
+        subject.check_preconditions(@worker, {})
       end
     end
-    context "when before block fails on the first attempt" do
-      it "should enqueue for later and return false" do
+    context "when before block returns false on the first attempt" do
+      it "should log and raise a SilentSidekiqError" do
         @worker.should_receive(:before).and_return(false)
-        Honeybadger.should_not_receive(:notify)
-        Sidekiq::Client.should_receive(:enqueue_in).with(10.seconds, DummySidekiqWorker, 'precondition_checks' => 2)
-        subject.check_preconditions(@worker, ['precondition_checks' => '1']).should be_false
+        Rails.logger.should_receive(:info)
+        expect {
+          subject.check_preconditions(@worker, 'retry_count' => '1', 'retry' => '5')
+        }.to raise_error(SilentSidekiqError)
       end
     end
-    context "when before block fails on the last attempt" do
-      it "should notify Honeybadger and return false" do
+    context "when before block returns false on the last attempt" do
+      it "should not log and raise a RuntimeError" do
         @worker.should_receive(:before).and_return(false)
+        Rails.logger.should_not_receive(:info)
+        expect {
+          subject.check_preconditions(@worker, 'retry_count' => '5', 'retry' => '5')
+        }.to raise_error("Attempted #{@worker.class}, but preconditions were never met!")
+      end
+    end
+    context "when before block throws an error on the first attempt" do
+      it "should notify Honeybadger and raise a SilentSidekiqError" do
+        @worker.should_receive(:before).and_raise('Runtime Error')
         Honeybadger.should_receive(:notify)
-        Sidekiq::Client.should_not_receive(:enqueue_in)
-        subject.check_preconditions(@worker, ['precondition_checks' => '5']).should be_false
+        expect {
+          subject.check_preconditions(@worker, 'retry_count' => '1', 'retry' => '5')
+        }.to raise_error(SilentSidekiqError)
+      end
+    end
+    context "when before block throws an error on the last attempt" do
+      it "should notify Honeybadger and raise a Runtime Error" do
+        @worker.should_receive(:before).and_raise('Runtime Error')
+        Honeybadger.should_receive(:notify)
+        expect {
+          subject.check_preconditions(@worker, 'retry_count' => '5', 'retry' => '5')
+        }.to raise_error("Attempted #{@worker.class}, but preconditions were never met!")
       end
     end
   end
@@ -93,24 +125,30 @@ describe JobChainsMiddleware do
     before do
       @worker = DummySidekiqWorker.new
     end
-    context "when after block passes" do
-      it "should return true" do
-        @worker.should_receive(:after).and_return(true)
-        subject.check_postconditions(@worker, [{}]).should be_true
+    context "when skip_after option is specified" do
+      it "should not check after block" do
+        @worker.should_not_receive(:after)
+        subject.check_preconditions(@worker, 'skip_after' => 'true')
       end
     end
-    context "when after block fails then passes" do
-      it "should return true" do
+    context "when after block passes" do
+      it "should succeed" do
+        @worker.should_receive(:after).and_return(true)
+        subject.check_postconditions(@worker, 'retry' => '5')
+      end
+    end
+    context "when after block fails then passes within max retires" do
+      it "should succeed and not notify Honeybadger" do
         @worker.should_receive(:after).twice.and_return(false, true)
         Honeybadger.should_not_receive(:notify)
-        subject.check_postconditions(@worker, [{}]).should be_true
+        subject.check_postconditions(@worker, 'retry' => '5')
       end
     end    
-    context "when after block fails" do
+    context "when after block fails max number of retries" do
       it "should notify Honeybadger and return false" do
         @worker.should_receive(:after).exactly(5).times.and_return(false)
         Honeybadger.should_receive(:notify)
-        subject.check_postconditions(@worker, [{}]).should be_false
+        subject.check_postconditions(@worker, 'retry' => '5').should be_false
       end
     end    
   end


### PR DESCRIPTION
- `before` and `after` blocks take in the same args as the `perform` block
- Instead of our own hacky retry logic, use Sidekiq's built-in retries--this means that jobs can "fail" if they throw an exception OR if their `before` block is not met!
- Optional arguments to skip before/after callbacks
